### PR TITLE
Make FCS_KYC_EXT.2 consistent with FDEEE

### DIFF
--- a/input/FDEAA.xml
+++ b/input/FDEAA.xml
@@ -3082,41 +3082,33 @@
           <audit/>
           <dependencies>No dependencies</dependencies>
           <f-element id="fcs-kyc-ext-2-1">
-            <title>The TSF shall accept a BEV of at least <selectables><selectable>128 bits</selectable><selectable>256 bits</selectable></selectables> from <assignable>one or more external entities</assignable>.</title>
+            <title>The TSF shall accept a BEV of at least 256 bits.</title>
             
           </f-element>
           <f-element id="fcs-kyc-ext-2-2">
             <title>
               The TSF shall maintain a chain of intermediary keys originating from the BEV to the DEK using the following methods: <selectables linebreak="yes">
-                <selectable>asymmetric key generation as specified in FCS_CKM.1/AKG</selectable>
-                <selectable id="fcs-kyc-ext-2-2-sel-2">symmetric key generation as specified in FCS_CKM.1/SKG</selectable>
-                <selectable>key derivation as specified in FCS_CKM.5.1</selectable>
-                <selectable>key wrapping as specified in FCS_COP.1/KeyWrap</selectable>
-                <selectable>key transport as specified in FCS_COP.1/KeyEncap</selectable>
-                <selectable>key encryption as specified in FCS_COP.1/KeyEnc</selectable>
-              </selectables> while maintaining an effective strength of <selectables>
-                <selectable>128 bits</selectable>
-                <selectable>256 bits</selectable>
-              </selectables>
-              while maintaining an effective strength of <selectables><selectable>128 bits</selectable>
-                <selectable>256 bits</selectable></selectables> for symmetric keys and an effective strength of <selectables><selectable>not applicable</selectable><selectable>112 bits</selectable><selectable>128 bits</selectable><selectable>192 bits</selectable><selectable>256 bits</selectable></selectables> for asymmetric keys.
+                <selectable id="fcs-kyc-ext-2-2-sel-1">key encryption as specified in FCS_COP.1/KeyEnc</selectable>
+                <selectable id="fcs-kyc-ext-2-2-sel-5">key transport as specified in FCS_COP.1/KeyEncap</selectable>
+                <selectable id="fcs-kyc-ext-2-2-sel-4">key wrapping as specified in FCS_COP.1/KeyWrap</selectable>
+                <selectable id="fcs-kyc-ext-2-2-sel-3">key derivation as specified in FCS_CKM.5</selectable>
+                <selectable id="fcs-kyc-ext-2-2-sel-2">key combining as specified in FCS_SMC_EXT.1</selectable>
+              </selectables> while maintaining an effective strength of [256 bits]
+              while maintaining an effective strength of [256 bits] for symmetric keys and an effective strength of <selectables><selectable>not applicable</selectable><selectable>128 bits</selectable><selectable>192 bits</selectable><selectable>256 bits</selectable></selectables> for asymmetric keys.
             </title>
             
             <ext-comp-def-title>
               <title>
                 The TSF shall maintain a chain of intermediary keys originating from the BEV to the DEK using the following methods: <selectables linebreak="yes">
-                  <selectable>asymmetric key generation as specified in FCS_CKM.1</selectable>
-                  <selectable id="fcs-kyc-ext-2-2-sel-2">symmetric key generation as specified in FCS_CKM.1</selectable>
-                  <selectable>key derivation as specified in FCS_CKM.5.1</selectable>
+                  <selectable>key derivation as specified in FCS_CKM.5</selectable>
                   <selectable>key wrapping as specified in FCS_COP.1</selectable>
-                  <selectable>key transport as specified in FCS_COP.1</selectable>
                   <selectable>key encryption as specified in FCS_COP.1</selectable>
+                  <selectable>key combining as specified in FCS_SMC_EXT.1</selectable>
                 </selectables> while maintaining an effective strength of <selectables>
                   <selectable>128 bits</selectable>
                   <selectable>256 bits</selectable>
                 </selectables>
-                while maintaining an effective strength of <selectables><selectable>128 bits</selectable>
-                  <selectable>256 bits</selectable></selectables> for symmetric keys and an effective strength of <selectables><selectable>not applicable</selectable><selectable>112 bits</selectable><selectable>128 bits</selectable><selectable>192 bits</selectable><selectable>256 bits</selectable></selectables> for asymmetric keys.
+                while maintaining an effective strength of [256 bits] for symmetric keys and an effective strength of <selectables><selectable>not applicable</selectable><selectable>128 bits</selectable><selectable>192 bits</selectable><selectable>256 bits</selectable></selectables> for asymmetric keys.
               </title>
             </ext-comp-def-title>
             <note role="application">Key Chaining is the method of using multiple layers of encryption keys to ultimately secure the protected data encrypted on the drive. The number of intermediate keys will vary – from one (e.g., using the BEV as a key encrypting key (KEK)) to many. This applies to all keys that contribute to the ultimate wrapping or derivation of the DEK; including those in areas of protected storage (e.g. TPM stored keys, comparison values). </note>


### PR DESCRIPTION
The definition was updated in FDEEE (https://github.com/commoncriteria/FDEEE/commit/e0867e9d1c2b28e8804a90d41f197ab13ea5dfcf)